### PR TITLE
Fix code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/staticfiles/admin/js/jquery-ui_1.10.2.js
+++ b/staticfiles/admin/js/jquery-ui_1.10.2.js
@@ -14052,7 +14052,7 @@
     },
   
     _sanitizeSelector: function( hash ) {
-      return hash ? hash.replace( /[!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g, "\\$&" ) : "";
+      return hash ? hash.replace(/\\/g, "\\\\").replace( /[!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g, "\\$&" ) : "";
     },
   
     refresh: function() {


### PR DESCRIPTION
Fixes [https://github.com/ouslan/jp-webapp/security/code-scanning/2](https://github.com/ouslan/jp-webapp/security/code-scanning/2)

To fix the problem, we need to ensure that backslashes are properly escaped in the `_sanitizeSelector` function. This can be done by modifying the regular expression used in the `replace` method to include backslashes. Specifically, we should add a rule to escape backslashes before escaping other special characters.

- Modify the `_sanitizeSelector` function to include backslashes in the regular expression used for escaping special characters.
- Ensure that the backslashes are escaped first to avoid double escaping issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
